### PR TITLE
Remove redundant code

### DIFF
--- a/R/main.R
+++ b/R/main.R
@@ -1,5 +1,5 @@
 css_to_xpath <- function(selector, prefix = "descendant-or-self::", translator = "generic") {
-    results <- Map(function(selector,prefix,translator) {
+    results <- Map(function(selector, prefix, translator) {
       tran <- if (translator == "html") {
         HTMLTranslator$new()
       } else if (translator == "xhtml") {


### PR DESCRIPTION
`Map()` is able to handle all vectorization so remove redundant code.
