### PR TITLE
Fix issue with length > 1 in logical comparison

### DIFF
--- a/R/parser.R
+++ b/R/parser.R
@@ -681,7 +681,7 @@ tokenize <- function(s) {
     while (pos <= len_s) {
         ss <- substring(s, pos, len_s)
         match <- match_whitespace(ss)
-        if (!is.na(match) && match[1] == 1) {
+        if (!anyNA(match) && match[1] == 1) {
             results[[i]] <- Token$new("S", " ", pos)
             match_end <- match[2]
             pos <- pos + match_end
@@ -689,7 +689,7 @@ tokenize <- function(s) {
             next
         }
         match <- match_number(ss)
-        if (!is.na(match) && match[1] == 1) {
+        if (!anyNA(match) && match[1] == 1) {
             match_start <- match[1]
             match_end <- max(match[1], match[2])
             value <- substring(ss, match_start, match_end)
@@ -699,7 +699,7 @@ tokenize <- function(s) {
             next
         }
         match <- match_ident(ss)
-        if (!is.na(match) && match[1] == 1) {
+        if (!anyNA(match) && match[1] == 1) {
             match_start <- match[1]
             match_end <- max(match[1], match[2])
             value <- substring(ss, match_start, match_end)
@@ -710,7 +710,7 @@ tokenize <- function(s) {
             next
         }
         match <- match_hash(ss)
-        if (!is.na(match) && match[1] == 1) {
+        if (!anyNA(match) && match[1] == 1) {
             match_start <- match[1]
             match_end <- max(match[1], match[2])
             value <- substring(ss, match_start, match_end)

--- a/tests/testthat/test-select-XML.R
+++ b/tests/testthat/test-select-XML.R
@@ -61,7 +61,7 @@ test_that("selection works correctly on a large barrage of tests", {
             for (i in seq_len(n)) {
                 tmp_res <- select_ids(selectors[i], html_only = html_only)
                 if (!is.null(result) && !is.null(tmp_res) &&
-                    tmp_res != result)
+                    !identical(tmp_res, result))
                     stop("Difference between results of selectors")
             }
         }

--- a/tests/testthat/test-select-xml2.R
+++ b/tests/testthat/test-select-xml2.R
@@ -61,7 +61,7 @@ test_that("selection works correctly on a large barrage of tests", {
             for (i in seq_len(n)) {
                 tmp_res <- select_ids(selectors[i], html_only = html_only)
                 if (!is.null(result) && !is.null(tmp_res) &&
-                    tmp_res != result)
+                    !identical(tmp_res, result))
                     stop("Difference between results of selectors")
             }
         }


### PR DESCRIPTION
Fixes #11 by using `!anyNA()` instead of `!is.na()` in `tokenize()`.

I also fixed a comparison in `pcss()` in the `test-select-XML` tests by using `identical()` instead of `==`.